### PR TITLE
Add AppMetrica daily installs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,20 @@ provided via environment variables:
   set)
 
 Ensure these variables are defined before running `Conv.py`.
+
+## Fetching daily AppMetrica installs
+
+The repository also includes `appmetrica_report.py` which retrieves the
+number of installations for the application **4661140** from Yandex AppMetrica.
+The script connects to the AppMetrica Logs API and counts organic and total
+installs for a selected day.
+
+Before running it, define the API token via the `APPMETRICA_TOKEN` environment
+variable:
+
+```bash
+export APPMETRICA_TOKEN=<your_api_token>
+python appmetrica_report.py 2025-06-01
+```
+
+If no date is passed, the script uses yesterday's date.

--- a/appmetrica_report.py
+++ b/appmetrica_report.py
@@ -1,0 +1,54 @@
+import csv
+import os
+import sys
+from datetime import datetime, timedelta
+from typing import Tuple
+
+import requests
+
+APP_ID = 4661140
+API_URL = "https://api.appmetrica.yandex.ru/logs/v1/export/installations.csv"
+TOKEN_ENV = "APPMETRICA_TOKEN"
+
+
+def fetch_installations(date: str) -> Tuple[int, int]:
+    token = os.getenv(TOKEN_ENV)
+    if not token:
+        raise RuntimeError(f"Environment variable {TOKEN_ENV} is required")
+
+    params = {
+        "application_id": APP_ID,
+        "date_since": date,
+        "date_until": date,
+        "fields": "tracker_name"
+    }
+
+    headers = {"Authorization": f"OAuth {token}"}
+    response = requests.get(API_URL, params=params, headers=headers)
+    response.raise_for_status()
+
+    total = 0
+    organic = 0
+    reader = csv.DictReader(response.text.splitlines(), delimiter=';')
+    for row in reader:
+        total += 1
+        tracker = row.get("tracker_name", "").strip().lower()
+        if tracker in ("", "organic", "(organic)"):
+            organic += 1
+    return total, organic
+
+
+def main():
+    if len(sys.argv) > 1:
+        date = sys.argv[1]
+    else:
+        date = (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+    total, organic = fetch_installations(date)
+    print(f"Date: {date}")
+    print(f"Organic installs: {organic}")
+    print(f"Total installs: {total} (non-organic: {total - organic})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to get daily install counts from AppMetrica
- document how to use the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416effb1cc8330bb0fd7a0b1f1fb7c